### PR TITLE
Install from official apt repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM ubuntu:12.04
 MAINTAINER Allan Espinosa "allan.espinosa@outlook.com"
 
+RUN apt-get install -y curl
 RUN echo deb http://archive.ubuntu.com/ubuntu precise universe >> /etc/apt/sources.list
+RUN curl http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key | apt-key add -
+RUN echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list
 RUN apt-get update
-RUN apt-get install -q -y openjdk-7-jre-headless
-ADD http://mirrors.jenkins-ci.org/war/latest/jenkins.war /root/jenkins.war
+RUN apt-get install -y jenkins=1.537
 
 EXPOSE 8080
-CMD ["java", "-jar", "/root/jenkins.war"]
+USER jenkins
+CMD ["java", "-jar", "/usr/share/jenkins/jenkins.war"]


### PR DESCRIPTION
It's a neater way to install it, plus we get a "jenkins" user.
