### PR TITLE
Add -P to command line for running container

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ Sets up a container with jenkins installed listening on port 8080.
 To run the container, do the following:
 
 ```
-docker run -d aespinosa/jenkins
+docker run -d -P aespinosa/jenkins
+
 docker ps
-ID                  IMAGE                     COMMAND                CREATED
-STATUS              PORTS
-f08460ebd8cc        aespinosa/jenkins:1.522   java -jar /root/jenk   20 minutes
-ago      Up 20 minutes       49153->8080
+CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                     NAMES
+1131d37c38b1        aespinosa/jenkins:latest    java -jar /opt/jenki   12 seconds ago      Up 12 seconds       0.0.0.0:49153->8080/tcp   drunk_fermi
 ```
 
 Your jenkins instance is now available by going to http://localhost:49153 .


### PR DESCRIPTION
Latest Docker releases do not expose ports unless the "-P" command line option is provided.

Tested with Docker 0.10

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
