### PR TITLE
README.md: Use standard markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,11 @@ Sets up a container with jenkins installed listening on port 8080.
 
 To run the container, do the following:
 
-```
-docker run -d -P aespinosa/jenkins
-
-docker ps
-CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                     NAMES
-1131d37c38b1        aespinosa/jenkins:latest    java -jar /opt/jenki   12 seconds ago      Up 12 seconds       0.0.0.0:49153->8080/tcp   drunk_fermi
-```
+    docker run -d -P aespinosa/jenkins
+    
+    docker ps
+    CONTAINER ID        IMAGE                       COMMAND                CREATED             STATUS              PORTS                     NAMES
+    1131d37c38b1        aespinosa/jenkins:latest    java -jar /opt/jenki   12 seconds ago      Up 12 seconds       0.0.0.0:49153->8080/tcp   drunk_fermi
 
 Your jenkins instance is now available by going to http://localhost:49153 .
 
@@ -20,16 +18,11 @@ Your jenkins instance is now available by going to http://localhost:49153 .
 
 To build the image, simply invoke
 
-```
-docker build github.com/aespinosa/docker-jenkins
-```
+    docker build github.com/aespinosa/docker-jenkins
 
 A prebuilt container is also available in the docker index
 
-```
-docker pull aespinosa/jenkins
-```
-
+    docker pull aespinosa/jenkins
 
 
 ## Author


### PR DESCRIPTION
Trivial patch to have the Information page on https://index.docker.io/ look pretty.

Unfortunately right now index.docker.io does not understand extended Github markdown syntax.

Test case: compare
https://index.docker.io/u/aespinosa/jenkins/
with
https://index.docker.io/u/gmacario/docker-jenkins/

Signed-off-by: Gianpaolo Macario gmacario@gmail.com
