### PR TITLE
Switch to ubuntu, Upgrade openjdk and jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get --no-install-recommends install -q -y openjdk-8-jre-headless && \
     rm -rf /var/lib/apt/lists/*
     
-ADD http://mirrors.jenkins-ci.org/war/2.86/jenkins.war /opt/jenkins.war
+ADD http://mirrors.jenkins-ci.org/war/2.87/jenkins.war /opt/jenkins.war
 RUN chmod 644 /opt/jenkins.war
 ENV JENKINS_HOME /jenkins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM debian:jessie
+FROM ubuntu:16.04
 MAINTAINER Allan Espinosa "allan.espinosa@outlook.com"
 
 RUN apt-get update && \
-    apt-get --no-install-recommends install -q -y openjdk-7-jre-headless && \
+    apt-get --no-install-recommends install -q -y openjdk-8-jre-headless && \
     rm -rf /var/lib/apt/lists/*
-ADD http://mirrors.jenkins-ci.org/war/2.20/jenkins.war /opt/jenkins.war
+    
+ADD http://mirrors.jenkins-ci.org/war/2.85/jenkins.war /opt/jenkins.war
 RUN chmod 644 /opt/jenkins.war
 ENV JENKINS_HOME /jenkins
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     apt-get --no-install-recommends install -q -y openjdk-8-jre-headless && \
     rm -rf /var/lib/apt/lists/*
     
-ADD http://mirrors.jenkins-ci.org/war/2.85/jenkins.war /opt/jenkins.war
+ADD http://mirrors.jenkins-ci.org/war/2.86/jenkins.war /opt/jenkins.war
 RUN chmod 644 /opt/jenkins.war
 ENV JENKINS_HOME /jenkins
 


### PR DESCRIPTION
Upgrade of openjdk8 and jenkins to 2.85 (newer jenkin versions require jre8)
Furthermore, changed the base image to ubuntu:16.04 as debian:jessie required adding backports to the pacakge sources resulting in additional commands. As this dockerfile's simplicity is nice imho, I thought it might be btter to change the base image instead.